### PR TITLE
Fixes Swift Package Manager Support

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "CocoaAsyncSocket",
+        "repositoryURL": "https://github.com/robbiehanson/CocoaAsyncSocket.git",
+        "state": {
+          "branch": null,
+          "revision": "dbdc00669c1ced63b27c3c5f052ee4d28f10150c",
+          "version": "7.6.5"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,8 +1,12 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(
     name: "Bagel",
+    platforms: [
+        .iOS(.v9),
+        .macOS(.v10_10),
+    ],
     products: [
         .library(name: "Bagel", targets: ["Bagel"])
     ],
@@ -13,7 +17,8 @@ let package = Package(
         .target(
             name: "Bagel",
             dependencies: ["CocoaAsyncSocket"],
-            path: "iOS/Source"
+            path: "iOS/Source",
+            publicHeadersPath: ""
         )
     ]
 )

--- a/iOS/Bagel.xcodeproj/project.pbxproj
+++ b/iOS/Bagel.xcodeproj/project.pbxproj
@@ -24,7 +24,7 @@
 		3760A46921F1383F004D1E07 /* BagelRequestCarrier.h in Headers */ = {isa = PBXBuildFile; fileRef = 3760A44F21F1383F004D1E07 /* BagelRequestCarrier.h */; };
 		3760A46A21F1383F004D1E07 /* BagelDeviceModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 3760A45021F1383F004D1E07 /* BagelDeviceModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3760A46B21F1383F004D1E07 /* BagelProjectModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 3760A45121F1383F004D1E07 /* BagelProjectModel.m */; };
-		3760A46C21F1383F004D1E07 /* BagelUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 3760A45221F1383F004D1E07 /* BagelUtility.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3760A46C21F1383F004D1E07 /* BagelUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 3760A45221F1383F004D1E07 /* BagelUtility.h */; };
 		3760A46D21F1383F004D1E07 /* BagelURLSessionInjector.h in Headers */ = {isa = PBXBuildFile; fileRef = 3760A45321F1383F004D1E07 /* BagelURLSessionInjector.h */; };
 		3760A46E21F1383F004D1E07 /* BagelRequestInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 3760A45421F1383F004D1E07 /* BagelRequestInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3760A46F21F1383F004D1E07 /* Bagel.h in Headers */ = {isa = PBXBuildFile; fileRef = 3760A45521F1383F004D1E07 /* Bagel.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -32,7 +32,7 @@
 		3760A47121F1383F004D1E07 /* BagelRequestPacket.m in Sources */ = {isa = PBXBuildFile; fileRef = 3760A45721F1383F004D1E07 /* BagelRequestPacket.m */; };
 		3760A47221F1383F004D1E07 /* BagelBrowser.h in Headers */ = {isa = PBXBuildFile; fileRef = 3760A45821F1383F004D1E07 /* BagelBrowser.h */; };
 		3760A47321F1383F004D1E07 /* BagelURLConnectionInjector.m in Sources */ = {isa = PBXBuildFile; fileRef = 3760A45921F1383F004D1E07 /* BagelURLConnectionInjector.m */; };
-		3760A47421F1383F004D1E07 /* BagelBaseModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 3760A45A21F1383F004D1E07 /* BagelBaseModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3760A47421F1383F004D1E07 /* BagelBaseModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 3760A45A21F1383F004D1E07 /* BagelBaseModel.h */; };
 		3760A47B21F13A47004D1E07 /* CocoaAsyncSocket.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3760A47A21F13A47004D1E07 /* CocoaAsyncSocket.framework */; };
 		51102CE2220B87290067EB63 /* BagelCarrierDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 51102CE1220B857E0067EB63 /* BagelCarrierDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */

--- a/iOS/Source/Bagel.h
+++ b/iOS/Source/Bagel.h
@@ -19,7 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <UIKit/UIKit.h>
+@import Foundation;
 
 //! Project version number for Bagel.
 FOUNDATION_EXPORT double BagelVersionNumber;
@@ -27,14 +27,12 @@ FOUNDATION_EXPORT double BagelVersionNumber;
 //! Project version string for Bagel.
 FOUNDATION_EXPORT const unsigned char BagelVersionString[];
 
-#import <Foundation/Foundation.h>
+@import Foundation;
 
-#import <Bagel/BagelBaseModel.h>
-#import <Bagel/BagelCarrierDelegate.h>
-#import <Bagel/BagelConfiguration.h>
-#import <Bagel/BagelDeviceModel.h>
-#import <Bagel/BagelProjectModel.h>
-#import <Bagel/BagelUtility.h>
+#import "BagelCarrierDelegate.h"
+#import "BagelConfiguration.h"
+#import "BagelDeviceModel.h"
+#import "BagelProjectModel.h"
 
 @interface Bagel : NSObject
 

--- a/iOS/Source/BagelBaseModel.h
+++ b/iOS/Source/BagelBaseModel.h
@@ -19,7 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <Foundation/Foundation.h>
+@import Foundation;
 
 @protocol BagelBaseModelProtocol <NSObject>
 

--- a/iOS/Source/BagelBrowser.m
+++ b/iOS/Source/BagelBrowser.m
@@ -56,7 +56,9 @@
 
     self.serviceBrowser = [[NSNetServiceBrowser alloc] init];
     [self.serviceBrowser setDelegate:self];
-    [self.serviceBrowser searchForServicesOfType:self.configuration.netserviceType inDomain:self.configuration.netserviceDomain];
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self.serviceBrowser searchForServicesOfType:self.configuration.netserviceType inDomain:self.configuration.netserviceDomain];
+    });
 }
 
 - (void)netServiceBrowser:(NSNetServiceBrowser*)serviceBrowser didFindService:(NSNetService*)service moreComing:(BOOL)moreComing

--- a/iOS/Source/BagelConfiguration.h
+++ b/iOS/Source/BagelConfiguration.h
@@ -19,11 +19,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <Foundation/Foundation.h>
-#import "BagelCarrierDelegate.h"
-#import "BagelProjectModel.h"
-#import "BagelDeviceModel.h"
-#import "BagelUtility.h"
+@import Foundation;
+
+@class BagelProjectModel;
+@class BagelDeviceModel;
+@protocol BagelCarrierDelegate;
 
 @interface BagelConfiguration : NSObject
 

--- a/iOS/Source/BagelConfiguration.m
+++ b/iOS/Source/BagelConfiguration.m
@@ -20,6 +20,9 @@
 // THE SOFTWARE.
 
 #import "BagelConfiguration.h"
+#import "BagelProjectModel.h"
+#import "BagelDeviceModel.h"
+#import "BagelUtility.h"
 
 static BagelConfiguration* defaultConfiguration;
 

--- a/iOS/Source/BagelController.m
+++ b/iOS/Source/BagelController.m
@@ -20,6 +20,7 @@
 // THE SOFTWARE.
 
 #import "BagelController.h"
+#import "BagelCarrierDelegate.h"
 
 static NSString* queueId = @"com.yagiz.bagel.injectController";
 

--- a/iOS/Source/BagelDeviceModel.h
+++ b/iOS/Source/BagelDeviceModel.h
@@ -19,9 +19,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "BagelBaseModel.h"
+@import Foundation;
 
-@interface BagelDeviceModel : NSObject <BagelBaseModelProtocol>
+@interface BagelDeviceModel : NSObject
 
 @property (nonatomic, strong) NSString* deviceId;
 @property (nonatomic, strong) NSString* deviceName;

--- a/iOS/Source/BagelProjectModel.h
+++ b/iOS/Source/BagelProjectModel.h
@@ -19,9 +19,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "BagelBaseModel.h"
+@import Foundation;
 
-@interface BagelProjectModel : NSObject <BagelBaseModelProtocol>
+@interface BagelProjectModel : NSObject
 
 @property (nonatomic, strong) NSString* projectName;
 

--- a/iOS/Source/BagelRequestPacket.m
+++ b/iOS/Source/BagelRequestPacket.m
@@ -20,6 +20,13 @@
 // THE SOFTWARE.
 
 #import "BagelRequestPacket.h"
+#import "BagelBaseModel.h"
+
+@interface BagelProjectModel()<BagelBaseModelProtocol>
+@end
+
+@interface BagelDeviceModel()<BagelBaseModelProtocol>
+@end
 
 @implementation BagelRequestPacket
 

--- a/iOS/Source/BagelUtility.h
+++ b/iOS/Source/BagelUtility.h
@@ -19,8 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
+@import Foundation;
 
 @interface BagelUtility : NSObject
 

--- a/iOS/Source/BagelUtility.m
+++ b/iOS/Source/BagelUtility.m
@@ -19,6 +19,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+@import Foundation;
+
+#if TARGET_OS_IOS
+@import UIKit;
+#endif
+
 #import "BagelUtility.h"
 
 @implementation BagelUtility
@@ -40,17 +46,24 @@
 
 + (NSString*)deviceName
 {
-    return [UIDevice currentDevice].name;
+#if TARGET_OS_IOS
+  return [UIDevice currentDevice].name;
+#else
+  return [[NSHost currentHost] localizedName];
+#endif
 }
 
 + (NSString*)deviceDescription
 {
-    NSString* information = @"";
+    NSString* information = nil;
 
+#if TARGET_OS_IOS
     information = [UIDevice currentDevice].model;
     information = [NSString stringWithFormat:@"%@ %@", information, [UIDevice currentDevice].systemName];
     information = [NSString stringWithFormat:@"%@ %@", information, [UIDevice currentDevice].systemVersion];
-
+#else
+    information = [[NSProcessInfo processInfo] operatingSystemVersionString];
+#endif
     return information;
 }
 


### PR DESCRIPTION
Updates Headers to only expose publicly;
- Bagel.h
- BagelCarrierDelegate.h
- BagelConfiguration.h
- BagelDeviceModel.h
- BagelProjectModel.h

All other headers are now project headers with forward declarations are added where required.

Adds support for macOS targets so that you can test the packages with with `% swift build`